### PR TITLE
wcコマンドを作成しました

### DIFF
--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -7,35 +7,46 @@ def main
   files = ARGV
   file_data = ARGV.select { |arg| File.file?(arg) } || $stdin.read
   option = options['l'] || options['w'] || options['c']
+  select_file_data(file_data, files, options, option)
+end
+
+def select_file_data(file_data, files, options, option)
   if file_data.empty?
-    option ? output_standard_input_options_count(options) : output_standard_input_count
-  elsif file_data.length >= 2
-    option ? output_multi_file_options_count(files, options) : output_multi_file_count(files)
+    output_standard_input_options_count(options, option)
   elsif file_data.length == 1
-    option ? output_files_count(file_data, options) : output_single_file_count(file_data)
+    output_files_count(file_data, options, option)
+  elsif file_data.length >= 2
+    output_multi_file_options_count(files, options, option)
   end
 end
 
-# 標準入力
-def output_standard_input_options_count(options)
-  input = $stdin.read
-  print input.count("\n").to_s.rjust(8) if options['l']
-  print input.split(/\s+/).size.to_s.rjust(8) if options['w']
-  print input.bytesize.to_s.rjust(8) if options['c']
+def output_standard_input_options_count(options, option)
+  if option
+    input = $stdin.read
+    print line_count(input).to_s.rjust(8) if options['l']
+    print word_count(input).to_s.rjust(8) if options['w']
+    print byte_count(input).to_s.rjust(8) if options['c']
+  else
+    output_standard_input_count
+  end
 end
 
 def output_standard_input_count
   input = $stdin.read
-  print input.count("\n").to_s.rjust(8)
-  print input.split(/\s+/).size.to_s.rjust(8)
-  print input.bytesize.to_s.rjust(8)
+  print line_count(input).to_s.rjust(8)
+  print word_count(input).to_s.rjust(8)
+  print byte_count(input).to_s.rjust(8)
 end
 
-def output_files_count(file_data, options)
-  output_line_count(file_data) if options['l']
-  output_word_count(file_data) if options['w']
-  output_byte_count(file_data) if options['c']
-  output_file(file_data)
+def output_files_count(file_data, options, option)
+  if option
+    output_line_count(file_data) if options['l']
+    output_word_count(file_data) if options['w']
+    output_byte_count(file_data) if options['c']
+    output_file(file_data)
+  else
+    output_single_file_count(file_data)
+  end
 end
 
 def output_single_file_count(file_data)
@@ -43,6 +54,18 @@ def output_single_file_count(file_data)
   output_word_count(file_data)
   output_byte_count(file_data)
   output_file(file_data)
+end
+
+def line_count(file_content)
+  file_content.count("\n").to_i
+end
+
+def word_count(file_content)
+  file_content.split(/\s+/).size.to_i
+end
+
+def byte_count(file_content)
+  file_content.bytesize.to_i
 end
 
 def output_line_count(file_data)
@@ -69,6 +92,30 @@ def output_file(file_data)
   end
 end
 
+def output_multi_file_options_count(files, options, option)
+  if option
+    total_lines = 0
+    total_words = 0
+    total_bytes = 0
+    files.each do |file|
+      file_content = File.read(file)
+      total_lines += line_count(file_content)
+      total_words += word_count(file_content)
+      total_bytes += byte_count(file_content)
+      print line_count(file_content).to_s.rjust(4) if options['l']
+      print word_count(file_content).to_s.rjust(4) if options['w']
+      print byte_count(file_content).to_s.rjust(6) if options['c']
+      print "#{file}\n".to_s.rjust(8)
+    end
+    print total_lines.to_s.rjust(4) if options['l']
+    print total_words.to_s.rjust(4) if options['w']
+    print total_bytes.to_s.rjust(6) if options['c']
+    print "total\n".to_s.rjust(8)
+  else
+    output_multi_file_count(files)
+  end
+end
+
 def output_multi_file_count(files)
   total_lines = 0
   total_words = 0
@@ -87,38 +134,6 @@ def output_multi_file_count(files)
   print total_words.to_s.rjust(4)
   print total_bytes.to_s.rjust(6)
   print "total\n".to_s.rjust(8)
-end
-
-def output_multi_file_options_count(files, options)
-  total_lines = 0
-  total_words = 0
-  total_bytes = 0
-  files.each do |file|
-    file_content = File.read(file)
-    total_lines += line_count(file_content)
-    total_words += word_count(file_content)
-    total_bytes += byte_count(file_content)
-    print line_count(file_content).to_s.rjust(4) if options['l']
-    print word_count(file_content).to_s.rjust(4) if options['w']
-    print byte_count(file_content).to_s.rjust(6) if options['c']
-    print "#{file}\n".to_s.rjust(8)
-  end
-  print total_lines.to_s.rjust(4) if options['l']
-  print total_words.to_s.rjust(4) if options['w']
-  print total_bytes.to_s.rjust(6) if options['c']
-  print "total\n".to_s.rjust(8)
-end
-
-def line_count(file_content)
-  file_content.count("\n").to_i
-end
-
-def word_count(file_content)
-  file_content.split(/\s+/).size.to_i
-end
-
-def byte_count(file_content)
-  file_content.bytesize.to_i
 end
 
 main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -7,7 +7,8 @@ def main
   files = ARGV
   file_data = ARGV.select { |arg| File.file?(arg) } || $stdin.read
   if file_data.empty?
-    output_standard_input_count(options)
+    output_standard_input_options_count(options) if options['l'] || options['w'] || options['c']
+    output_standard_input_count
   else
     output_files_count(options, file_data) if options['l'] || options['w'] || options['c']
     output_multi_file_count(files, file_data) if file_data.length >= 2
@@ -15,20 +16,46 @@ def main
 end
 
 # 標準入力
-def output_standard_input_count(options)
+def output_standard_input_options_count(options)
   input = $stdin.read
-  print input.count("\n").to_s.ljust(8) if options['l']
-  print input.split(/\s+/).size.to_s.ljust(8) if options['w']
-  print input.bytesize.to_s.ljust(8) if options['c']
+  if options.empty?
+    print output_standard_input_count
+  else
+    print input.count("\n").to_s.ljust(8) if options['l']
+    print input.split(/\s+/).size.to_s.ljust(8) if options['w']
+    print input.bytesize.to_s.ljust(8) if options['c']
+  end
+end
+
+# 標準入力、オプションなし
+def output_standard_input_count
+  input = $stdin.read
+  print input.count("\n").to_s.ljust(8)
+  print input.split(/\s+/).size.to_s.ljust(8)
+  print input.bytesize.to_s.ljust(8)
 end
 
 # オプション
 def output_files_count(options, file_data)
+  if options.empty?
+    output_single_file_count(file_data)
+  else
+    file_data.each do |file|
+      line_count(file_data) if options['l']
+      word_count(file_data) if options['w']
+      byte_count(file_data) if options['c']
+      print "#{file}\n"
+    end
+  end
+end
+
+# ファイルひとつ
+def output_single_file_count(file_data)
   file_data.each do |file|
-    line_count(file_data) if options['l']
-    word_count(file_data) if options['w']
-    byte_count(file_data) if options['c']
-    print "#{file}\n"
+    print File.read(file).count("\n").to_s.ljust(4)
+    print File.read(file).split(/\s+/).size.to_s.ljust(4)
+    print File.read(file).bytesize.to_s.ljust(5)
+    print "#{file}\n".to_s.rjust(7)
   end
 end
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -12,7 +12,7 @@ end
 
 def select_file_data(file_data, files, options, option)
   if file_data.empty?
-    output_standard_input_options_count(options, option)
+    output_standard_input_count(options, option)
   elsif file_data.length == 1
     output_files_count(file_data, options, option)
   elsif file_data.length >= 2
@@ -20,39 +20,17 @@ def select_file_data(file_data, files, options, option)
   end
 end
 
-def output_standard_input_options_count(options, option)
-  if option
-    input = $stdin.read
-    print line_count(input).to_s.rjust(8) if options['l']
-    print word_count(input).to_s.rjust(8) if options['w']
-    print byte_count(input).to_s.rjust(8) if options['c']
-  else
-    output_standard_input_count
-  end
-end
-
-def output_standard_input_count
+def output_standard_input_count(options, option)
   input = $stdin.read
-  print line_count(input).to_s.rjust(8)
-  print word_count(input).to_s.rjust(8)
-  print byte_count(input).to_s.rjust(8)
+  print line_count(input).to_s.rjust(8) if !option || options['l']
+  print word_count(input).to_s.rjust(8) if !option || options['w']
+  print byte_count(input).to_s.rjust(8) if !option || options['c']
 end
 
 def output_files_count(file_data, options, option)
-  if option
-    output_line_count(file_data) if options['l']
-    output_word_count(file_data) if options['w']
-    output_byte_count(file_data) if options['c']
-    output_file(file_data)
-  else
-    output_single_file_count(file_data)
-  end
-end
-
-def output_single_file_count(file_data)
-  output_line_count(file_data)
-  output_word_count(file_data)
-  output_byte_count(file_data)
+  output_line_count(file_data) if !option || options['l']
+  output_word_count(file_data) if !option || options['w']
+  output_byte_count(file_data) if !option || options['c']
   output_file(file_data)
 end
 
@@ -93,46 +71,25 @@ def output_file(file_data)
 end
 
 def output_multi_file_options_count(files, options, option)
-  if option
-    total_lines = 0
-    total_words = 0
-    total_bytes = 0
-    files.each do |file|
-      file_content = File.read(file)
-      total_lines += line_count(file_content)
-      total_words += word_count(file_content)
-      total_bytes += byte_count(file_content)
-      print line_count(file_content).to_s.rjust(4) if options['l']
-      print word_count(file_content).to_s.rjust(4) if options['w']
-      print byte_count(file_content).to_s.rjust(6) if options['c']
-      print "#{file}\n".to_s.rjust(8)
-    end
-    print total_lines.to_s.rjust(4) if options['l']
-    print total_words.to_s.rjust(4) if options['w']
-    print total_bytes.to_s.rjust(6) if options['c']
-    print "total\n".to_s.rjust(8)
-  else
-    output_multi_file_count(files)
-  end
-end
-
-def output_multi_file_count(files)
   total_lines = 0
   total_words = 0
   total_bytes = 0
   files.each do |file|
     file_content = File.read(file)
-    total_lines += line_count(file_content)
-    total_words += word_count(file_content)
-    total_bytes += byte_count(file_content)
-    print line_count(file_content).to_s.rjust(4)
-    print word_count(file_content).to_s.rjust(4)
-    print byte_count(file_content).to_s.rjust(6)
+    line_count = line_count(file_content)
+    word_count = word_count(file_content)
+    byte_count = byte_count(file_content)
+    print line_count.to_s.rjust(4) if !option || options['l']
+    print word_count.to_s.rjust(4) if !option || options['w']
+    print byte_count.to_s.rjust(6) if !option || options['c']
     print "#{file}\n".to_s.rjust(8)
+    total_lines += line_count
+    total_words += word_count
+    total_bytes += byte_count
   end
-  print total_lines.to_s.rjust(4)
-  print total_words.to_s.rjust(4)
-  print total_bytes.to_s.rjust(6)
+  print total_lines.to_s.rjust(4) if !option || options['l']
+  print total_words.to_s.rjust(4) if !option || options['w']
+  print total_bytes.to_s.rjust(6) if !option || options['c']
   print "total\n".to_s.rjust(8)
 end
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -7,8 +7,7 @@ def main
   files = ARGV
   file_data = ARGV.select { |arg| File.file?(arg) } || $stdin.read
   if file_data.empty?
-    output_standard_input_options_count(options) if options['l'] || options['w'] || options['c']
-    output_standard_input_count
+    output_standard_input_options_count(options)
   else
     output_files_count(options, file_data) if options['l'] || options['w'] || options['c']
     output_multi_file_count(files, file_data) if file_data.length >= 2
@@ -18,18 +17,17 @@ end
 # 標準入力
 def output_standard_input_options_count(options)
   input = $stdin.read
-  if options.empty?
-    print output_standard_input_count
-  else
+  if options['l'] || options['w'] || options['c']
     print input.count("\n").to_s.ljust(8) if options['l']
     print input.split(/\s+/).size.to_s.ljust(8) if options['w']
     print input.bytesize.to_s.ljust(8) if options['c']
+  else
+    output_standard_input_count(input)
   end
 end
 
 # 標準入力、オプションなし
-def output_standard_input_count
-  input = $stdin.read
+def output_standard_input_count(input)
   print input.count("\n").to_s.ljust(8)
   print input.split(/\s+/).size.to_s.ljust(8)
   print input.bytesize.to_s.ljust(8)

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -4,33 +4,33 @@ require 'optparse'
 
 def main
   options = ARGV.getopts('lwc')
+  options = { 'l' => true, 'w' => true, 'c' => true } if options.values.none?
   files = ARGV
-  file_data = ARGV.select { |arg| File.file?(arg) } || $stdin.read
-  option = options['l'] || options['w'] || options['c']
-  select_file_data(file_data, files, options, option)
+  file_data = ARGV.select { |filename| File.file?(filename) } || $stdin.read
+  select_file_data(file_data, files, options)
 end
 
-def select_file_data(file_data, files, options, option)
+def select_file_data(file_data, files, options)
   if file_data.empty?
-    output_standard_input_count(options, option)
+    output_standard_input_count(options)
   elsif file_data.length == 1
-    output_files_count(file_data, options, option)
+    output_files_count(file_data, options)
   elsif file_data.length >= 2
-    output_multi_file_options_count(files, options, option)
+    output_multi_file_options_count(files, options)
   end
 end
 
-def output_standard_input_count(options, option)
+def output_standard_input_count(options)
   input = $stdin.read
-  print line_count(input).to_s.rjust(8) if !option || options['l']
-  print word_count(input).to_s.rjust(8) if !option || options['w']
-  print byte_count(input).to_s.rjust(8) if !option || options['c']
+  print line_count(input).to_s.rjust(8) if options['l']
+  print word_count(input).to_s.rjust(8) if options['w']
+  print byte_count(input).to_s.rjust(8) if options['c']
 end
 
-def output_files_count(file_data, options, option)
-  output_line_count(file_data) if !option || options['l']
-  output_word_count(file_data) if !option || options['w']
-  output_byte_count(file_data) if !option || options['c']
+def output_files_count(file_data, options)
+  output_line_count(file_data) if options['l']
+  output_word_count(file_data) if options['w']
+  output_byte_count(file_data) if options['c']
   output_file(file_data)
 end
 
@@ -70,7 +70,7 @@ def output_file(file_data)
   end
 end
 
-def output_multi_file_options_count(files, options, option)
+def output_multi_file_options_count(files, options)
   total_lines = 0
   total_words = 0
   total_bytes = 0
@@ -79,17 +79,17 @@ def output_multi_file_options_count(files, options, option)
     line_count = line_count(file_content)
     word_count = word_count(file_content)
     byte_count = byte_count(file_content)
-    print line_count.to_s.rjust(4) if !option || options['l']
-    print word_count.to_s.rjust(4) if !option || options['w']
-    print byte_count.to_s.rjust(6) if !option || options['c']
+    print line_count.to_s.rjust(4) if options['l']
+    print word_count.to_s.rjust(4) if options['w']
+    print byte_count.to_s.rjust(6) if options['c']
     print "#{file}\n".to_s.rjust(8)
     total_lines += line_count
     total_words += word_count
     total_bytes += byte_count
   end
-  print total_lines.to_s.rjust(4) if !option || options['l']
-  print total_words.to_s.rjust(4) if !option || options['w']
-  print total_bytes.to_s.rjust(6) if !option || options['c']
+  print total_lines.to_s.rjust(4) if options['l']
+  print total_words.to_s.rjust(4) if options['w']
+  print total_bytes.to_s.rjust(6) if options['c']
   print "total\n".to_s.rjust(8)
 end
 

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+def main
+  options = ARGV.getopts('lwc')
+  files = Dir.glob('*')
+  if options['l'] && options['w'] && options['c']
+    output_for_line_word_byte_count(files)
+  elsif options['l'] && options['w']
+    output_for_line_word_count(files)
+  elsif options['w'] && options['c']
+    output_for_word_byte_count(files)
+  elsif options['l'] && options['c']
+    output_for_line_byte_count(files)
+  elsif options['l']
+    output_for_line_count(files)
+  elsif options['w']
+    output_for_word_count(files)
+  elsif options['c']
+    output_for_byte_count(files)
+  elsif ARGV[0]
+    output_for_file_names(files)
+  else
+    output_for_standard_input(files)
+  end
+end
+
+def output_for_line_word_byte_count(files)
+  file = files.pop
+  print File.read(file).count("\n").to_s.ljust(4)
+  print word_count(file).to_s.ljust(4)
+  print byte_count(file).to_s.ljust(5)
+  print "#{file}\n".to_s.ljust(4)
+end
+
+def output_for_line_word_count(files)
+  file = files.pop
+  print File.read(file).count("\n").to_s.ljust(4)
+  print word_count(file).to_s.ljust(4)
+  print "#{file}\n".to_s.ljust(4)
+end
+
+def output_for_word_byte_count(files)
+  file = files.pop
+  print word_count(file).to_s.ljust(4)
+  print byte_count(file).to_s.ljust(5)
+  print "#{file}\n".to_s.ljust(4)
+end
+
+def output_for_line_byte_count(files)
+  file = files.pop
+  print File.read(file).count("\n").to_s.ljust(4)
+  print byte_count(file).to_s.ljust(5)
+  print "#{file}\n".to_s.ljust(4)
+end
+
+def output_for_line_count(files)
+  file = files.pop
+  output_line_count(file)
+end
+
+def output_for_word_count(files)
+  file = files.pop
+  output_word_count(file)
+end
+
+def output_for_byte_count(files)
+  file = files.pop
+  output_byte_count(file)
+end
+
+def line_count(file)
+  File.read(file).count("\n")
+end
+
+def word_count(file)
+  words = File.read(file).split(/\s+/).size
+  words.to_i
+end
+
+def byte_count(file)
+  bytes = File.read(file).bytesize
+  bytes.to_i
+end
+
+def total_line_count(files)
+  files.sum { |file| line_count(file) }
+end
+
+def total_word_count(files)
+  files.sum { |file| word_count(file) }
+end
+
+def total_byte_count(files)
+  files.sum { |file| byte_count(file) }
+end
+
+def output_line_count(file)
+  print File.read(file).count("\n").to_s.ljust(4)
+  print "#{file}\n"
+end
+
+def output_word_count(file)
+  print word_count(file).to_s.ljust(4)
+  print "#{file}\n"
+end
+
+def output_byte_count(file)
+  print byte_count(file).to_s.ljust(5)
+  print "#{file}\n "
+end
+
+def output_for_standard_input(_files)
+  input = $stdin.read
+  output_standard_input_count(input)
+end
+
+def output_standard_input_count(input)
+  print input.count("\n").to_s.ljust(8)
+  print input.split(/\s+/).size.to_s.ljust(8)
+  print "#{input.bytesize.to_s.ljust(8)}\n"
+end
+
+def output_for_file_names(files)
+  files.each do |file|
+    print File.read(file).count("\n").to_s.rjust(4)
+    print word_count(file).to_s.rjust(5)
+    print byte_count(file).to_s.rjust(5)
+    print "#{file}\n".to_s.rjust(7)
+  end
+  print total_line_count(files).to_s.rjust(4)
+  print total_word_count(files).to_s.rjust(5)
+  print total_byte_count(files).to_s.rjust(5)
+  print "total\n".to_s.rjust(7)
+end
+
+main

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -30,24 +30,27 @@ def output_multi_file_count(file_data, options)
     line_count = line_count(file_content)
     word_count = word_count(file_content)
     byte_count = byte_count(file_content)
-    output_line_count(line_count, options)
-    output_word_count(word_count, options)
-    output_byte_count(byte_count, options)
+    output_terms_count(line_count, word_count, byte_count, options)
     output_file_name(file)
     total_lines += line_count
     total_words += word_count
     total_bytes += byte_count
   end
-  output_line_count(total_lines, options)
-  output_word_count(total_words, options)
-  output_byte_count(total_bytes, options)
+  output_terms_count(total_lines, total_words, total_bytes, options)
   output_file_name('total')
 end
 
+def output_terms_count(line_count, word_count, byte_count, options)
+  output_line_count(line_count, options)
+  output_word_count(word_count, options)
+  output_byte_count(byte_count, options)
+end
+
 def output_count(file_content, options)
-  output_line_count(line_count(file_content), options)
-  output_word_count(word_count(file_content), options)
-  output_byte_count(byte_count(file_content), options)
+  line_count = line_count(file_content)
+  word_count = word_count(file_content)
+  byte_count = byte_count(file_content)
+  output_terms_count(line_count, word_count, byte_count, options)
 end
 
 def line_count(file_content)

--- a/06.wc/wc.rb
+++ b/06.wc/wc.rb
@@ -6,95 +6,119 @@ def main
   options = ARGV.getopts('lwc')
   files = ARGV
   file_data = ARGV.select { |arg| File.file?(arg) } || $stdin.read
+  option = options['l'] || options['w'] || options['c']
   if file_data.empty?
-    output_standard_input_options_count(options)
-  else
-    output_files_count(options, file_data) if options['l'] || options['w'] || options['c']
-    output_multi_file_count(files, file_data) if file_data.length >= 2
+    option ? output_standard_input_options_count(options) : output_standard_input_count
+  elsif file_data.length >= 2
+    option ? output_multi_file_options_count(files, options) : output_multi_file_count(files)
+  elsif file_data.length == 1
+    option ? output_files_count(file_data, options) : output_single_file_count(file_data)
   end
 end
 
 # 標準入力
 def output_standard_input_options_count(options)
   input = $stdin.read
-  if options['l'] || options['w'] || options['c']
-    print input.count("\n").to_s.ljust(8) if options['l']
-    print input.split(/\s+/).size.to_s.ljust(8) if options['w']
-    print input.bytesize.to_s.ljust(8) if options['c']
-  else
-    output_standard_input_count(input)
-  end
+  print input.count("\n").to_s.rjust(8) if options['l']
+  print input.split(/\s+/).size.to_s.rjust(8) if options['w']
+  print input.bytesize.to_s.rjust(8) if options['c']
 end
 
-# 標準入力、オプションなし
-def output_standard_input_count(input)
-  print input.count("\n").to_s.ljust(8)
-  print input.split(/\s+/).size.to_s.ljust(8)
-  print input.bytesize.to_s.ljust(8)
+def output_standard_input_count
+  input = $stdin.read
+  print input.count("\n").to_s.rjust(8)
+  print input.split(/\s+/).size.to_s.rjust(8)
+  print input.bytesize.to_s.rjust(8)
 end
 
-# オプション
-def output_files_count(options, file_data)
-  if options.empty?
-    output_single_file_count(file_data)
-  else
-    file_data.each do |file|
-      line_count(file_data) if options['l']
-      word_count(file_data) if options['w']
-      byte_count(file_data) if options['c']
-      print "#{file}\n"
-    end
-  end
+def output_files_count(file_data, options)
+  output_line_count(file_data) if options['l']
+  output_word_count(file_data) if options['w']
+  output_byte_count(file_data) if options['c']
+  output_file(file_data)
 end
 
-# ファイルひとつ
 def output_single_file_count(file_data)
+  output_line_count(file_data)
+  output_word_count(file_data)
+  output_byte_count(file_data)
+  output_file(file_data)
+end
+
+def output_line_count(file_data)
   file_data.each do |file|
-    print File.read(file).count("\n").to_s.ljust(4)
-    print File.read(file).split(/\s+/).size.to_s.ljust(4)
-    print File.read(file).bytesize.to_s.ljust(5)
-    print "#{file}\n".to_s.rjust(7)
+    print File.read(file).count("\n").to_s.rjust(4)
   end
 end
 
-# 行数える
-def line_count(file_data)
+def output_word_count(file_data)
   file_data.each do |file|
-    print File.read(file).count("\n").to_s.ljust(4)
+    print File.read(file).split(/\s+/).size.to_s.rjust(4)
   end
 end
 
-# 単語数数える
-def word_count(file_data)
+def output_byte_count(file_data)
   file_data.each do |file|
-    print File.read(file).split(/\s+/).size.to_s.ljust(4)
+    print File.read(file).bytesize.to_s.rjust(6)
   end
 end
 
-# バイト数数える
-def byte_count(file_data)
+def output_file(file_data)
   file_data.each do |file|
-    print File.read(file).bytesize.to_s.ljust(5)
+    print "#{file}\n".to_s.rjust(8)
   end
 end
 
-# ファイル名が複数個のとき
-def output_multi_file_count(files, _file_data)
+def output_multi_file_count(files)
   total_lines = 0
   total_words = 0
   total_bytes = 0
   files.each do |file|
     file_content = File.read(file)
-    total_lines += file_content.count("\n")
-    total_words += file_content.split(/\s+/).size
-    total_bytes += file_content.bytesize
-    print file_content.count("\n").to_s.ljust(4)
-    print file_content.split(/\s+/).size.to_s.ljust(4)
-    print file_content.bytesize.to_s.ljust(5)
-    print "#{file}\n".to_s.rjust(7)
+    total_lines += line_count(file_content)
+    total_words += word_count(file_content)
+    total_bytes += byte_count(file_content)
+    print line_count(file_content).to_s.rjust(4)
+    print word_count(file_content).to_s.rjust(4)
+    print byte_count(file_content).to_s.rjust(6)
+    print "#{file}\n".to_s.rjust(8)
   end
-  print total_lines.to_s.ljust(4) + total_words.to_s.ljust(4) + total_bytes.to_s.ljust(5)
-  print "total\n".to_s.rjust(7)
+  print total_lines.to_s.rjust(4)
+  print total_words.to_s.rjust(4)
+  print total_bytes.to_s.rjust(6)
+  print "total\n".to_s.rjust(8)
+end
+
+def output_multi_file_options_count(files, options)
+  total_lines = 0
+  total_words = 0
+  total_bytes = 0
+  files.each do |file|
+    file_content = File.read(file)
+    total_lines += line_count(file_content)
+    total_words += word_count(file_content)
+    total_bytes += byte_count(file_content)
+    print line_count(file_content).to_s.rjust(4) if options['l']
+    print word_count(file_content).to_s.rjust(4) if options['w']
+    print byte_count(file_content).to_s.rjust(6) if options['c']
+    print "#{file}\n".to_s.rjust(8)
+  end
+  print total_lines.to_s.rjust(4) if options['l']
+  print total_words.to_s.rjust(4) if options['w']
+  print total_bytes.to_s.rjust(6) if options['c']
+  print "total\n".to_s.rjust(8)
+end
+
+def line_count(file_content)
+  file_content.count("\n").to_i
+end
+
+def word_count(file_content)
+  file_content.split(/\s+/).size.to_i
+end
+
+def byte_count(file_content)
+  file_content.bytesize.to_i
 end
 
 main


### PR DESCRIPTION
## 概要
- ファイル名を引数とする場合、パイプを使って標準入力を受け取る場合の動作を再現する。
- `l` `w` `c` オプション
- `lw` `wc` `lc` `lwc`オプション
- 引数にファイル名が複数個来た場合
- lsコマンドと自作のwcコマンドをつなげた出力
- lsコマンドと自作のwcコマンドをつなげた場合の`l` `w` `c` オプション
- lsコマンドと自作のwcコマンドをつなげた場合の複数オプション
## 変更点
- `files = Dir.glob('*')` → `files = ARGV`に変更しました。
- `l` `w` `c` オプションをそれぞれ独立して使うことができるように修正しました。
- 組み合わせごとに指定する必要がなくなったため`output_for_line_word_byte_count(files)`等のメソッドは削除しました。